### PR TITLE
VersionChecker.java: Fix error

### DIFF
--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/VersionChecker.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/VersionChecker.java
@@ -36,7 +36,9 @@ public class VersionChecker {
     }
 
     public void stop() {
-        thread.interrupt();
+    if (this.thread != null) {
+        this.thread.interrupt();
+    }
     }
 
     private void run(int interval) {


### PR DESCRIPTION
```
[17:21:13 ERROR]: Error occurred while disabling SilkSpawners_v2 v2.3.2 (Is it up to date?)
[17:21:13 ERROR]: Suspected Plugins:
[17:21:13 ERROR]:       PlugManX{enabled,ver=2.4.1,path=plugins/PlugManX-2.4.1.jar}
[17:21:13 ERROR]:       SilkSpawners_v2{disabled,ver=2.3.2,path=plugins/SilkSpawners_v2.jar}
[17:21:13 ERROR]: Exception details below:
java.lang.NullPointerException: Cannot invoke "java.lang.Thread.interrupt()" because "this.thread" is null
        at de.corneliusmay.silkspawners.plugin.version.VersionChecker.stop(VersionChecker.java:39) ~[?:?]
        at de.corneliusmay.silkspawners.plugin.SilkSpawners.onDisable(SilkSpawners.java:105) ~[?:?]
        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:265) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at org.bukkit.plugin.java.JavaPluginLoader.disablePlugin(JavaPluginLoader.java:409) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at org.bukkit.plugin.SimplePluginManager.disablePlugin(SimplePluginManager.java:533) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at org.bukkit.plugin.SimplePluginManager.disablePlugin(SimplePluginManager.java:525) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at com.rylinaux.plugman.pluginmanager.BukkitPluginManager.unload(BukkitPluginManager.java:529) ~[?:?]
        at com.rylinaux.plugman.command.UnloadCommand.execute(UnloadCommand.java:114) ~[?:?]
        at com.rylinaux.plugman.PlugManCommandHandler.onCommand(PlugManCommandHandler.java:94) ~[?:?]
        at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at org.bukkit.craftbukkit.v1_16_R3.CraftServer.dispatchCommand(CraftServer.java:826) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at org.bukkit.craftbukkit.v1_16_R3.CraftServer.dispatchServerCommand(CraftServer.java:788) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at net.minecraft.server.v1_16_R3.DedicatedServer.handleCommandQueue(DedicatedServer.java:491) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at net.minecraft.server.v1_16_R3.DedicatedServer.b(DedicatedServer.java:458) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at net.minecraft.server.v1_16_R3.MinecraftServer.a(MinecraftServer.java:1411) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at net.minecraft.server.v1_16_R3.MinecraftServer.w(MinecraftServer.java:1138) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at net.minecraft.server.v1_16_R3.MinecraftServer.lambda$a$0(MinecraftServer.java:293) ~[patched_1.16.5.jar:git-Patina-ver/1.16.5-"667fb1b"]
        at java.lang.Thread.run(Thread.java:840) [?:?]
```
when the `enabled: false` parameter is set in `config.yml` in the `update` section, we get this error, no matter how the plugin stops, by the server itself or `plugmanx`