### PR TITLE
fix: support new Paper version string format

### DIFF
--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/MinecraftVersion.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/MinecraftVersion.java
@@ -4,6 +4,8 @@ import lombok.Getter;
 import org.bukkit.Bukkit;
 
 import java.util.logging.Level;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 class MinecraftVersion {
 
@@ -15,8 +17,9 @@ class MinecraftVersion {
 
     static {
         try {
-            // Split on the "-" to just get the version information
-            version = Bukkit.getServer().getBukkitVersion().split("-")[0];
+            final Matcher matcher = Pattern.compile("^\\d+(\\.\\d+)+").matcher(Bukkit.getServer().getBukkitVersion());
+            if (!matcher.find()) throw new IllegalArgumentException("Unrecognized Minecraft version string");
+            version = matcher.group();
             final String[] splitVersion = version.split("\\.");
 
             majorVersion = Integer.parseInt(splitVersion[0]);


### PR DESCRIPTION
Paper now reports the Bukkit version as "<mcversion>.build.<build>-<status>" (e.g. "26.2.build.34-stable") following Mojang's switch to calendar versioning, which broke the previous parser with a NumberFormatException. Extract the Minecraft version as the leading digits-and-dots prefix instead of assuming the legacy "-R0.1-SNAPSHOT" shape.

Fixes #73