### PR TITLE
fix: folia support

### DIFF
--- a/API/src/main/java/de/corneliusmay/silkspawners/api/ServerPlatform.java
+++ b/API/src/main/java/de/corneliusmay/silkspawners/api/ServerPlatform.java
@@ -1,6 +1,7 @@
 package de.corneliusmay.silkspawners.api;
 
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public abstract class ServerPlatform {
@@ -11,4 +12,6 @@ public abstract class ServerPlatform {
     }
 
     public abstract void runTaskLater(Location location, Runnable runnable, long delay);
+
+    public abstract void runOnEntity(Entity entity, Runnable runnable, Runnable retired);
 }

--- a/PlatformBukkit/src/main/java/de/corneliusmay/silkspawners/platform/bukkit/PlatformImplementation.java
+++ b/PlatformBukkit/src/main/java/de/corneliusmay/silkspawners/platform/bukkit/PlatformImplementation.java
@@ -3,6 +3,7 @@ package de.corneliusmay.silkspawners.platform.bukkit;
 import de.corneliusmay.silkspawners.api.ServerPlatform;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class PlatformImplementation extends ServerPlatform {
@@ -13,5 +14,14 @@ public class PlatformImplementation extends ServerPlatform {
     @Override
     public void runTaskLater(Location location, Runnable runnable, long delay) {
         Bukkit.getScheduler().runTaskLater(this.plugin, runnable, delay);
+    }
+
+    @Override
+    public void runOnEntity(Entity entity, Runnable runnable, Runnable retired) {
+        if (Bukkit.isPrimaryThread()) runnable.run();
+        else Bukkit.getScheduler().runTask(this.plugin, () -> {
+            if (entity.isValid()) runnable.run();
+            else retired.run();
+        });
     }
 }

--- a/PlatformFolia/src/main/java/de/corneliusmay/silkspawners/platform/folia/PlatformImplementation.java
+++ b/PlatformFolia/src/main/java/de/corneliusmay/silkspawners/platform/folia/PlatformImplementation.java
@@ -1,7 +1,9 @@
 package de.corneliusmay.silkspawners.platform.folia;
 
 import de.corneliusmay.silkspawners.api.ServerPlatform;
+import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.entity.Entity;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class PlatformImplementation extends ServerPlatform {
@@ -12,5 +14,11 @@ public class PlatformImplementation extends ServerPlatform {
     @Override
     public void runTaskLater(Location location, Runnable runnable, long delay) {
         this.plugin.getServer().getRegionScheduler().runDelayed(this.plugin, location, task -> runnable.run(), delay);
+    }
+
+    @Override
+    public void runOnEntity(Entity entity, Runnable runnable, Runnable retired) {
+        if(Bukkit.isOwnedByCurrentRegion(entity)) runnable.run();
+        else if(entity.getScheduler().run(this.plugin, task -> runnable.run(), retired) == null) retired.run();
     }
 }

--- a/Plugin/build.gradle.kts
+++ b/Plugin/build.gradle.kts
@@ -10,7 +10,7 @@ var bukkit = "org.bukkit:bukkit:1.15.2-R0.1-SNAPSHOT"
 dependencies {
     compileOnly(bukkit)
 
-    implementation("org.bstats:bstats-bukkit:3.0.0")
+    implementation("org.bstats:bstats-bukkit:3.1.0")
 
     implementation(project(":API"))
     implementation(project(":PlatformBukkit"))

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/SilkSpawners.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/SilkSpawners.java
@@ -19,12 +19,11 @@ import de.corneliusmay.silkspawners.plugin.version.VersionChecker;
 import de.corneliusmay.silkspawners.plugin.version.CrossVersionHandler;
 import lombok.Getter;
 import org.bstats.bukkit.Metrics;
-import org.bukkit.block.Block;
+import org.bukkit.Location;
 import org.bukkit.plugin.java.JavaPlugin;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Getter
 public class SilkSpawners extends JavaPlugin {
@@ -83,7 +82,7 @@ public class SilkSpawners extends JavaPlugin {
     }
 
     private void registerListeners() {
-        List<Block> editedSpawners = Collections.synchronizedList(new ArrayList<>());
+        Set<Location> editedSpawners = ConcurrentHashMap.newKeySet();
         SilkSpawnersEventHandler eventHandler = new SilkSpawnersEventHandler(this);
         eventHandler.registerListener(new PlayerInteractListener(editedSpawners));
         eventHandler.registerListener(new BlockPlaceListener(editedSpawners));

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/SilkSpawners.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/SilkSpawners.java
@@ -108,7 +108,7 @@ public class SilkSpawners extends JavaPlugin {
         commandHandler.register();
     }
 
-    public boolean reloadConfiguration() {
+    public synchronized boolean reloadConfiguration() {
         if(!configLoader.reload()) return false;
         versionChecker.restart();
         return true;

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/ExplosionCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/ExplosionCommand.java
@@ -6,7 +6,6 @@ import de.corneliusmay.silkspawners.plugin.commands.completers.OnlinePlayersTabC
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.bukkit.permissions.PermissionAttachment;
 
 public class ExplosionCommand extends SilkSpawnersCommand {
 
@@ -24,18 +23,21 @@ public class ExplosionCommand extends SilkSpawnersCommand {
             return false;
         }
 
-        PermissionAttachment attachment = p.addAttachment(plugin);
         switch (args[0].toLowerCase()) {
-            case "enable", "e" -> {
-                attachment.setPermission("silkspawners.explosion", true);
+            case "enable", "e" -> plugin.getPlatform().runOnEntity(p, () -> {
+                p.addAttachment(plugin).setPermission("silkspawners.explosion", true);
                 sendMessage(sender, "ENABLED", p.getName());
-            }
-            case "disable", "d" -> {
-                attachment.setPermission("silkspawners.explosion", false);
+            }, () -> sendMessage(sender, "PLAYER_NOT_FOUND", p.getName()));
+            case "disable", "d" -> plugin.getPlatform().runOnEntity(p, () -> {
+                p.addAttachment(plugin).setPermission("silkspawners.explosion", false);
                 sendMessage(sender, "DISABLED", p.getName());
+            }, () -> sendMessage(sender, "PLAYER_NOT_FOUND", p.getName()));
+            case "setting", "s" -> plugin.getPlatform().runOnEntity(p,
+                    () -> sendMessage(sender, "SETTING_" + (p.hasPermission("silkspawners.explosion")? "ENABLED" : "DISABLED"), p.getName()),
+                    () -> sendMessage(sender, "PLAYER_NOT_FOUND", p.getName()));
+            default -> {
+                return invalidSyntax(sender);
             }
-            case "setting", "s" -> sendMessage(sender, "SETTING_" + (p.hasPermission("silkspawners.explosion")? "ENABLED" : "DISABLED"), p.getName());
-            default -> invalidSyntax(sender);
         }
         return true;
     }

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/GiveCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/GiveCommand.java
@@ -63,14 +63,17 @@ public class GiveCommand extends SilkSpawnersCommand {
 
         ItemStack item = spawner.getItemStack();
         item.setAmount(amount);
-        p.getInventory().addItem(item);
+        int finalAmount = amount;
         String trailingLetter = amount > 1? "s" : "";
-        if(p != sender) {
-            sendMessage(sender, "SUCCESS", amount, spawner.serializedName(), trailingLetter, p.getName());
-            sendMessage(p, "SUCCESS_TARGET", amount, spawner.serializedName(), trailingLetter, sender.getName());
-        } else {
-            sendMessage(sender, "SUCCESS_SELF", amount, spawner.serializedName(), trailingLetter);
-        }
+        plugin.getPlatform().runOnEntity(p, () -> {
+            p.getInventory().addItem(item);
+            if(p != sender) {
+                sendMessage(sender, "SUCCESS", finalAmount, spawner.serializedName(), trailingLetter, p.getName());
+                sendMessage(p, "SUCCESS_TARGET", finalAmount, spawner.serializedName(), trailingLetter, sender.getName());
+            } else {
+                sendMessage(sender, "SUCCESS_SELF", finalAmount, spawner.serializedName(), trailingLetter);
+            }
+        }, () -> sendMessage(sender, "PLAYER_NOT_FOUND", p.getName()));
         return true;
     }
 

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/SetCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/SetCommand.java
@@ -8,7 +8,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
-import java.util.ArrayList;
+import java.util.HashSet;
 
 public class SetCommand extends SilkSpawnersCommand {
 
@@ -52,7 +52,7 @@ public class SetCommand extends SilkSpawnersCommand {
             sendMessage(sender, "INVALID_TARGET");
             return false;
         }
-        newSpawner.setSpawnerBlockType(block, new ArrayList<>());
+        newSpawner.setSpawnerBlockType(block, new HashSet<>());
         sendMessage(sender, "SUCCESS", newSpawner.serializedName());
         return true;
     }

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/VersionCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/VersionCommand.java
@@ -20,8 +20,9 @@ public class VersionCommand extends SilkSpawnersCommand {
             return false;
         }
 
-        if(plugin.getVersionChecker().check()) sendMessage(sender, "INFO", plugin.getVersionChecker().getInstalledVersion());
-        else sendMessage(sender, "UPDATE_AVAILABLE", plugin.getVersionChecker().getInstalledVersion(), plugin.getVersionChecker().getLatestVersion());
+        String latestVersion = plugin.getVersionChecker().getLatestVersion();
+        if(plugin.getVersionChecker().check(latestVersion)) sendMessage(sender, "INFO", plugin.getVersionChecker().getInstalledVersion());
+        else sendMessage(sender, "UPDATE_AVAILABLE", plugin.getVersionChecker().getInstalledVersion(), latestVersion);
         return true;
     }
 }

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/listeners/BlockPlaceListener.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/listeners/BlockPlaceListener.java
@@ -6,20 +6,20 @@ import de.corneliusmay.silkspawners.plugin.config.PluginConfig;
 import de.corneliusmay.silkspawners.plugin.listeners.handler.SilkSpawnersListener;
 import de.corneliusmay.silkspawners.plugin.spawner.Spawner;
 import org.bukkit.Bukkit;
-import org.bukkit.block.Block;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.inventory.ItemStack;
 
-import java.util.List;
+import java.util.Set;
 
 public class BlockPlaceListener extends SilkSpawnersListener<BlockPlaceEvent> {
 
-    private final List<Block> editedSpawners;
+    private final Set<Location> editedSpawners;
 
-    public BlockPlaceListener(List<Block> editedSpawners){
+    public BlockPlaceListener(Set<Location> editedSpawners){
         this.editedSpawners = editedSpawners;
     }
 
@@ -48,7 +48,7 @@ public class BlockPlaceListener extends SilkSpawnersListener<BlockPlaceEvent> {
             e.setCancelled(true);
             return;
         }
-        this.editedSpawners.add(e.getBlock());
+        this.editedSpawners.add(e.getBlock().getLocation());
         event.getSpawner().setSpawnerBlockType(e.getBlock(), this.editedSpawners);
     }
 

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/listeners/PlayerInteractListener.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/listeners/PlayerInteractListener.java
@@ -11,13 +11,13 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 
-import java.util.List;
+import java.util.Set;
 
 public class PlayerInteractListener extends SilkSpawnersListener<PlayerInteractEvent> {
 
-    private final List<Block> editedSpawners;
+    private final Set<Location> editedSpawners;
 
-    public PlayerInteractListener(List<Block> editedSpawners) {
+    public PlayerInteractListener(Set<Location> editedSpawners) {
         this.editedSpawners = editedSpawners;
     }
 
@@ -30,11 +30,10 @@ public class PlayerInteractListener extends SilkSpawnersListener<PlayerInteractE
         Spawner spawner = new Spawner(plugin, block);
         if(!spawner.isValid()) return;
 
-        if(editedSpawners.stream().anyMatch(b -> b.getLocation().equals(blockLocation))) {
+        if(!editedSpawners.add(blockLocation)) {
             e.setCancelled(true);
             return;
         }
-        editedSpawners.add(block);
 
         this.plugin.getPlatform().runTaskLater(blockLocation, () -> {
             Spawner newSpawner = new Spawner(plugin, block.getWorld().getBlockAt(blockLocation));
@@ -46,7 +45,7 @@ public class PlayerInteractListener extends SilkSpawnersListener<PlayerInteractE
                 spawner.setSpawnerBlockType(block, this.editedSpawners);
                 if(new ConfigValue<Boolean>(PluginConfig.SPAWNER_MESSAGE_DENY_CHANGE).get()) e.getPlayer().sendMessage(plugin.getLocale().getMessage("SPAWNER_CHANGE_DENIED"));
             } else {
-                editedSpawners.remove(block);
+                editedSpawners.remove(blockLocation);
             }
         }, 1);
     }

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/locale/LocaleHandler.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/locale/LocaleHandler.java
@@ -22,7 +22,7 @@ public class LocaleHandler {
     private final File localePath;
 
     @Getter
-    private ResourceBundle resourceBundle;
+    private volatile ResourceBundle resourceBundle;
 
     public LocaleHandler(SilkSpawners plugin) {
         this.plugin = plugin;
@@ -39,7 +39,7 @@ public class LocaleHandler {
         }
     }
 
-    public void copyDefaultLocales(boolean overwrite) throws URISyntaxException, IOException {
+    public synchronized void copyDefaultLocales(boolean overwrite) throws URISyntaxException, IOException {
         Path target = Paths.get(plugin.getDataFolder() + "/locale");
         URI resource = getClass().getResource("").toURI();
         FileSystem fileSystem = FileSystems.newFileSystem(resource, Collections.<String, String>emptyMap());
@@ -63,7 +63,7 @@ public class LocaleHandler {
         fileSystem.close();
     }
 
-    public void loadLocale() throws MalformedURLException {
+    public synchronized void loadLocale() throws MalformedURLException {
         URL[] urls = {localePath.toURI().toURL()};
         ClassLoader loader = new URLClassLoader(urls);
         this.resourceBundle = ResourceBundle.getBundle("messages", getLocale(), loader);

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/spawner/Spawner.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/spawner/Spawner.java
@@ -6,7 +6,7 @@ import de.corneliusmay.silkspawners.plugin.config.PluginConfig;
 import de.corneliusmay.silkspawners.plugin.utils.ItemBuilder;
 import de.corneliusmay.silkspawners.plugin.utils.StringUtils;
 import lombok.Getter;
-import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.block.CreatureSpawner;
@@ -14,6 +14,7 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.inventory.ItemStack;
 
 import java.util.List;
+import java.util.Set;
 
 public class Spawner {
     public static String EMPTY = "empty";
@@ -52,9 +53,13 @@ public class Spawner {
         this.itemStack = generateItemStack();
     }
 
-    public void setSpawnerBlockType(Block block, List<Block> editedList) {
+    public void setSpawnerBlockType(Block block, Set<Location> editedList) {
+        setSpawnerBlockType(block, () -> editedList.remove(block.getLocation()));
+    }
+
+    private void setSpawnerBlockType(Block block, Runnable removeFromEditedList) {
         if(!isValid()){
-            editedList.remove(block);
+            removeFromEditedList.run();
             return;
         }
         this.plugin.getPlatform().runTaskLater(block.getLocation(), () -> {
@@ -63,7 +68,7 @@ public class Spawner {
             CreatureSpawner creatureSpawner = (CreatureSpawner) blockState;
             creatureSpawner.setSpawnedType(this.entityType);
             blockState.update();
-            editedList.remove(block);
+            removeFromEditedList.run();
         }, 1);
     }
 

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/VersionChecker.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/VersionChecker.java
@@ -23,7 +23,7 @@ public class VersionChecker {
     private final HttpClient client;
 
     @Getter
-    private String latestVersion;
+    private volatile String latestVersion;
 
     private Thread thread;
 
@@ -34,13 +34,13 @@ public class VersionChecker {
         client = HttpClient.newHttpClient();
     }
 
-    public void start() {
+    public synchronized void start() {
         Integer interval = configuredInterval();
         if (interval != null) start(interval);
         else plugin.getLog().warn("Update checking is disabled");
     }
 
-    public void restart() {
+    public synchronized void restart() {
         if (thread != null && thread.isAlive() && Objects.equals(configuredInterval(), runningInterval)) return;
         stop();
         start();
@@ -58,7 +58,7 @@ public class VersionChecker {
         thread.start();
     }
 
-    public void stop() {
+    public synchronized void stop() {
         if (this.thread != null) {
             this.thread.interrupt();
             this.thread = null;
@@ -71,9 +71,12 @@ public class VersionChecker {
             while (true) {
                 plugin.getLog().info("Checking for updates");
                 if (!update()) plugin.getLog().error("Error getting latest version");
-                else if (!check())
-                    plugin.getLog().warn("§eUpdate available! Download at https://www.spigotmc.org/resources/silkspawners.60063/ §f\nInstalled version: v" + getInstalledVersion() + "\nLatest version: v" + latestVersion);
-                else plugin.getLog().info("The plugin is up to date (Current release v" + latestVersion + ")");
+                else {
+                    String currentLatestVersion = this.latestVersion;
+                    if (!check(currentLatestVersion))
+                        plugin.getLog().warn("§eUpdate available! Download at https://www.spigotmc.org/resources/silkspawners.60063/ §f\nInstalled version: v" + getInstalledVersion() + "\nLatest version: v" + currentLatestVersion);
+                    else plugin.getLog().info("The plugin is up to date (Current release v" + currentLatestVersion + ")");
+                }
                 TimeUnit.HOURS.sleep(interval);
             }
         } catch (InterruptedException ignored) {
@@ -97,9 +100,10 @@ public class VersionChecker {
         }
     }
 
-    public boolean check() {
+    public boolean check(String currentLatestVersion) {
+        if (currentLatestVersion == null) return true;
         Integer[] installedVersion = castVersionString(getInstalledVersion());
-        Integer[] latestVersion = castVersionString(this.latestVersion);
+        Integer[] latestVersion = castVersionString(currentLatestVersion);
         for (int i = 0; i < latestVersion.length; i++) {
             if (i >= installedVersion.length) return true;
             if (latestVersion[i] > installedVersion[i]) return false;


### PR DESCRIPTION
fix(metrics): update bstats to 3.1.0 for folia support
fix(commands): run player modifications on the target's owning thread
fix(spawner): make edited spawner tracking thread-safe
fix(config): prevent concurrent configuration reloads
fix(locale): make locale reloading thread-safe
fix(version): make version checker state thread-safe