### PR TITLE
build: release version 3

### DIFF
--- a/.assets/hangar/description.md
+++ b/.assets/hangar/description.md
@@ -52,10 +52,10 @@ spawner:
   silktouchRequired: true # If set to false, spawners will drop even if the used pickaxe does not have SilkTouch
   silktouchLevel: 1 # The minimum SilkTouch level the pickaxe needs to mine spawners (useful for custom pickaxes with higher enchantment levels)
   item:
-    name: $dSpawner # The name of the spawner item dropped
-    prefix: $e # The text before the spawner name in the lore
-    prefixOld: '' # If you change your prefix, set this value to your old prefix to keep existing spawners functional
-    lore: [] # Set an array for this value to set a custom lore
+    name: $d{entity} Spawner # The name of the spawner item dropped, {entity} is replaced with the mob name
+    color: $e # The color of the mob name in chat messages
+    prefixOld: [] # Lore prefixes used by spawner items from older plugin versions, kept so those items stay recognized
+    lore: ['$7Spawns $e{entity}'] # The lore of the spawner item, {entity} is replaced with the mob name
   explosion:
     all: [] # Explosion tiers rolled whenever spawners are mined, with or without SilkTouch (see below)
     normal: [] # Explosion tiers rolled when spawners are mined without SilkTouch (see below)
@@ -69,7 +69,7 @@ spawner:
     disablePlace: false # If set to true, no permission is required to place spawners
     disableChange: false # If set to true, no permission is required to change spawners with eggs
 update:
-  configVersion: 3 # Do not change this value manually! It is automatically managed by the plugin
+  configVersion: 4 # Do not change this value manually! It is automatically managed by the plugin
   check:
     enabled: true # If set to true, the plugin will check for updates
     interval: 24 # The interval in hours at which to check for updates
@@ -99,7 +99,7 @@ spawner:
       breakBlocks: true # Optional: the explosion damages surrounding blocks (default true)
 ```
 
-All tier options are described in the [README](https://github.com/CorneliusMa/SilkSpawners_v2#configuration). Changes to the tiers take effect after `/silkspawners config reload` or a server restart.
+Changes to the tiers take effect after `/silkspawners config reload` or a server restart.
 
 ## Custom messages
 ![Crowdin Localization](https://badges.crowdin.net/silkspawners/localized.svg)
@@ -132,6 +132,7 @@ COMMAND_SILKSPAWNERS_HELP_MESSAGE_SET = $7Use this command to change already pla
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_ENTITIES = $7Use this command to see entities that can be used in commands and permissions. \nUsage\: /silkspawners entities
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_VERSION = $7Use this command to see, if updates are available. \nUsage\: /silkspawners version
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_LOCALE = $7Use this command to see the currently used locale, to reload the locale files and to update them from the .jar file. Updating may be necessary if new messages have been added in an update. \n$eWarning\! All custom changes will be lost if not previously saved\!$7\nUsage\: /silkspawners locale [setting/reload/update]
+COMMAND_SILKSPAWNERS_HELP_MESSAGE_CONFIG = $7Use this command to reload the configuration from the config.yml file. \nUsage\: /silkspawners config reload
 
 COMMAND_SILKSPAWNERS_GIVE_USAGE = $ePlease use /silkspawners give <Player> <Mob> [Amount]
 COMMAND_SILKSPAWNERS_GIVE_PLAYER_NOT_FOUND = $7The player $c{0}$7 is not online.
@@ -149,6 +150,7 @@ COMMAND_SILKSPAWNERS_SET_ENTITY_NOT_FOUND = $7The entity $c{0}$7 is no valid spa
 COMMAND_SILKSPAWNERS_SET_INSUFFICIENT_ENTITY_PERMISSION = $7You do not have the permission to set spawners to $c{0}$7.
 COMMAND_SILKSPAWNERS_SET_INVALID_TARGET = $7You must look at a spawner to change.
 COMMAND_SILKSPAWNERS_SET_SUCCESS = $7Successfully set spawner to {0}$7.
+COMMAND_SILKSPAWNERS_SET_UNCHANGED = $7The spawner is already set to {0}$7.
 
 COMMAND_SILKSPAWNERS_EXPLOSION_USAGE = $ePlease use /silkspawners explosion <enable/disable/setting> <Player>
 COMMAND_SILKSPAWNERS_EXPLOSION_PLAYER_NOT_FOUND = $7The Player $c{0}$7 is not online.
@@ -169,6 +171,7 @@ COMMAND_SILKSPAWNERS_LOCALE_USAGE = $ePlease use /silkspawners locale [setting/r
 COMMAND_SILKSPAWNERS_LOCALE_SETTING = $7The currently used locale is {0}. Available locales are\: {1}
 COMMAND_SILKSPAWNERS_LOCALE_RELOAD_SUCCESSFUL = $7The locale was reloaded successfully.
 COMMAND_SILKSPAWNERS_LOCALE_RELOAD_ERROR = $cAn error occurred reloading the locale.
+COMMAND_SILKSPAWNERS_LOCALE_INCOMPLETE = $eThe locale {0} is incomplete ({1}% translated).$7 Untranslated messages are shown in English.\nYou can help completing the translation at {2}
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_WARNING = $eWarning\!$7 Updating the locale files will $coverwrite all changes$7.\n If you want to proceed, run /silkspawners locale update confirm.
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_SUCCESSFUL = $7The locale files were updated and reloaded successfully.
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_ERROR = $cAn error occurred.$7 Please contact the developer if this problem persists.
@@ -185,12 +188,15 @@ Common questions and problems are answered in the [FAQ](https://github.com/Corne
 
 ## Integrations
 
+### EconomyShopGUI
+[EconomyShopGUI](https://www.spigotmc.org/resources/economyshopgui.69927/) supports SilkSpawners out of the box, so spawners bought and sold in its shops are SilkSpawners items. Its `spawner-provider` option detects SilkSpawners automatically when set to `AUTO` (the default), or can be pinned with `spawner-provider: SILKSPAWNERSV2`.
+
 ### ShopGUI+
 If [ShopGUI+](https://www.spigotmc.org/resources/shopgui-1-8-1-21.6515/) is installed, SilkSpawners automatically registers itself as its spawner provider, so spawners bought and sold in shops are SilkSpawners items. The hook can be disabled by setting `hooks.shopguiplus` to `false` in the configuration.
 
 ## For developers
 
-SilkSpawners fires custom Bukkit events (`SpawnerPlaceEvent`, `SpawnerBreakEvent`) that other plugins can listen to. See [Developer documentation](https://github.com/CorneliusMa/SilkSpawners_v2/blob/master/docs/DEVELOPERS.md) for details.
+SilkSpawners provides a developer API with a `SilkSpawnersAPI` service and custom Bukkit events. See the [Developer documentation](https://github.com/CorneliusMa/SilkSpawners_v2/blob/master/docs/DEVELOPERS.md) for details.
 
 ## Tutorial
 

--- a/.assets/modrinth/description.md
+++ b/.assets/modrinth/description.md
@@ -52,10 +52,10 @@ spawner:
   silktouchRequired: true # If set to false, spawners will drop even if the used pickaxe does not have SilkTouch
   silktouchLevel: 1 # The minimum SilkTouch level the pickaxe needs to mine spawners (useful for custom pickaxes with higher enchantment levels)
   item:
-    name: $dSpawner # The name of the spawner item dropped
-    prefix: $e # The text before the spawner name in the lore
-    prefixOld: '' # If you change your prefix, set this value to your old prefix to keep existing spawners functional
-    lore: [] # Set an array for this value to set a custom lore
+    name: $d{entity} Spawner # The name of the spawner item dropped, {entity} is replaced with the mob name
+    color: $e # The color of the mob name in chat messages
+    prefixOld: [] # Lore prefixes used by spawner items from older plugin versions, kept so those items stay recognized
+    lore: ['$7Spawns $e{entity}'] # The lore of the spawner item, {entity} is replaced with the mob name
   explosion:
     all: [] # Explosion tiers rolled whenever spawners are mined, with or without SilkTouch (see below)
     normal: [] # Explosion tiers rolled when spawners are mined without SilkTouch (see below)
@@ -69,7 +69,7 @@ spawner:
     disablePlace: false # If set to true, no permission is required to place spawners
     disableChange: false # If set to true, no permission is required to change spawners with eggs
 update:
-  configVersion: 3 # Do not change this value manually! It is automatically managed by the plugin
+  configVersion: 4 # Do not change this value manually! It is automatically managed by the plugin
   check:
     enabled: true # If set to true, the plugin will check for updates
     interval: 24 # The interval in hours at which to check for updates
@@ -99,7 +99,7 @@ spawner:
       breakBlocks: true # Optional: the explosion damages surrounding blocks (default true)
 ```
 
-All tier options are described in the [README](https://github.com/CorneliusMa/SilkSpawners_v2#configuration). Changes to the tiers take effect after `/silkspawners config reload` or a server restart.
+Changes to the tiers take effect after `/silkspawners config reload` or a server restart.
 
 ## Custom messages
 ![Crowdin Localization](https://badges.crowdin.net/silkspawners/localized.svg)
@@ -132,6 +132,7 @@ COMMAND_SILKSPAWNERS_HELP_MESSAGE_SET = $7Use this command to change already pla
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_ENTITIES = $7Use this command to see entities that can be used in commands and permissions. \nUsage\: /silkspawners entities
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_VERSION = $7Use this command to see, if updates are available. \nUsage\: /silkspawners version
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_LOCALE = $7Use this command to see the currently used locale, to reload the locale files and to update them from the .jar file. Updating may be necessary if new messages have been added in an update. \n$eWarning\! All custom changes will be lost if not previously saved\!$7\nUsage\: /silkspawners locale [setting/reload/update]
+COMMAND_SILKSPAWNERS_HELP_MESSAGE_CONFIG = $7Use this command to reload the configuration from the config.yml file. \nUsage\: /silkspawners config reload
 
 COMMAND_SILKSPAWNERS_GIVE_USAGE = $ePlease use /silkspawners give <Player> <Mob> [Amount]
 COMMAND_SILKSPAWNERS_GIVE_PLAYER_NOT_FOUND = $7The player $c{0}$7 is not online.
@@ -149,6 +150,7 @@ COMMAND_SILKSPAWNERS_SET_ENTITY_NOT_FOUND = $7The entity $c{0}$7 is no valid spa
 COMMAND_SILKSPAWNERS_SET_INSUFFICIENT_ENTITY_PERMISSION = $7You do not have the permission to set spawners to $c{0}$7.
 COMMAND_SILKSPAWNERS_SET_INVALID_TARGET = $7You must look at a spawner to change.
 COMMAND_SILKSPAWNERS_SET_SUCCESS = $7Successfully set spawner to {0}$7.
+COMMAND_SILKSPAWNERS_SET_UNCHANGED = $7The spawner is already set to {0}$7.
 
 COMMAND_SILKSPAWNERS_EXPLOSION_USAGE = $ePlease use /silkspawners explosion <enable/disable/setting> <Player>
 COMMAND_SILKSPAWNERS_EXPLOSION_PLAYER_NOT_FOUND = $7The Player $c{0}$7 is not online.
@@ -169,6 +171,7 @@ COMMAND_SILKSPAWNERS_LOCALE_USAGE = $ePlease use /silkspawners locale [setting/r
 COMMAND_SILKSPAWNERS_LOCALE_SETTING = $7The currently used locale is {0}. Available locales are\: {1}
 COMMAND_SILKSPAWNERS_LOCALE_RELOAD_SUCCESSFUL = $7The locale was reloaded successfully.
 COMMAND_SILKSPAWNERS_LOCALE_RELOAD_ERROR = $cAn error occurred reloading the locale.
+COMMAND_SILKSPAWNERS_LOCALE_INCOMPLETE = $eThe locale {0} is incomplete ({1}% translated).$7 Untranslated messages are shown in English.\nYou can help completing the translation at {2}
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_WARNING = $eWarning\!$7 Updating the locale files will $coverwrite all changes$7.\n If you want to proceed, run /silkspawners locale update confirm.
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_SUCCESSFUL = $7The locale files were updated and reloaded successfully.
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_ERROR = $cAn error occurred.$7 Please contact the developer if this problem persists.
@@ -185,12 +188,15 @@ Common questions and problems are answered in the [FAQ](https://github.com/Corne
 
 ## Integrations
 
+### EconomyShopGUI
+[EconomyShopGUI](https://www.spigotmc.org/resources/economyshopgui.69927/) supports SilkSpawners out of the box, so spawners bought and sold in its shops are SilkSpawners items. Its `spawner-provider` option detects SilkSpawners automatically when set to `AUTO` (the default), or can be pinned with `spawner-provider: SILKSPAWNERSV2`.
+
 ### ShopGUI+
 If [ShopGUI+](https://www.spigotmc.org/resources/shopgui-1-8-1-21.6515/) is installed, SilkSpawners automatically registers itself as its spawner provider, so spawners bought and sold in shops are SilkSpawners items. The hook can be disabled by setting `hooks.shopguiplus` to `false` in the configuration.
 
 ## For developers
 
-SilkSpawners fires custom Bukkit events (`SpawnerPlaceEvent`, `SpawnerBreakEvent`) that other plugins can listen to. See [Developer documentation](https://github.com/CorneliusMa/SilkSpawners_v2/blob/master/docs/DEVELOPERS.md) for details.
+SilkSpawners provides a developer API with a `SilkSpawnersAPI` service and custom Bukkit events. See the [Developer documentation](https://github.com/CorneliusMa/SilkSpawners_v2/blob/master/docs/DEVELOPERS.md) for details.
 
 ## Tutorial
 

--- a/.assets/spigot/description.bbcode
+++ b/.assets/spigot/description.bbcode
@@ -55,10 +55,10 @@ spawner:
   silktouchRequired: true # If set to false, spawners will drop even if the used pickaxe does not have SilkTouch
   silktouchLevel: 1 # The minimum SilkTouch level the pickaxe needs to mine spawners (useful for custom pickaxes with higher enchantment levels)
   item:
-    name: $dSpawner # The name of the spawner item dropped
-    prefix: $e # The text before the spawner name in the lore
-    prefixOld: '' # If you change your prefix, set this value to your old prefix to keep existing spawners functional
-    lore: [] # Set an array for this value to set a custom lore
+    name: $d{entity} Spawner # The name of the spawner item dropped, {entity} is replaced with the mob name
+    color: $e # The color of the mob name in chat messages
+    prefixOld: [] # Lore prefixes used by spawner items from older plugin versions, kept so those items stay recognized
+    lore: ['$7Spawns $e{entity}'] # The lore of the spawner item, {entity} is replaced with the mob name
   explosion:
     all: [] # Explosion tiers rolled whenever spawners are mined, with or without SilkTouch (see below)
     normal: [] # Explosion tiers rolled when spawners are mined without SilkTouch (see below)
@@ -72,7 +72,7 @@ spawner:
     disablePlace: false # If set to true, no permission is required to place spawners
     disableChange: false # If set to true, no permission is required to change spawners with eggs
 update:
-  configVersion: 3 # Do not change this value manually! It is automatically managed by the plugin
+  configVersion: 4 # Do not change this value manually! It is automatically managed by the plugin
   check:
     enabled: true # If set to true, the plugin will check for updates
     interval: 24 # The interval in hours at which to check for updates
@@ -96,7 +96,7 @@ All messages (in the configuration and in locale files) can be formatted with ei
       power: 8.0
       setFire: true # Optional: the explosion ignites fires (default false)
       breakBlocks: true # Optional: the explosion damages surrounding blocks (default true)[/CODE][/QUOTE]
-[SIZE=4]All tier options are described in the [URL='https://github.com/CorneliusMa/SilkSpawners_v2#configuration']README[/URL]. Changes to the tiers take effect after /silkspawners config reload or a server restart.[/SIZE]
+[SIZE=4]Changes to the tiers take effect after /silkspawners config reload or a server restart.[/SIZE]
 
 
 [B][FONT=Verdana][SIZE=6][COLOR=#0059b3]Custom messages[/COLOR][/SIZE][/FONT][/B]
@@ -125,6 +125,7 @@ COMMAND_SILKSPAWNERS_HELP_MESSAGE_SET = $7Use this command to change already pla
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_ENTITIES = $7Use this command to see entities that can be used in commands and permissions. \nUsage\: /silkspawners entities
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_VERSION = $7Use this command to see, if updates are available. \nUsage\: /silkspawners version
 COMMAND_SILKSPAWNERS_HELP_MESSAGE_LOCALE = $7Use this command to see the currently used locale, to reload the locale files and to update them from the .jar file. Updating may be necessary if new messages have been added in an update. \n$eWarning\! All custom changes will be lost if not previously saved\!$7\nUsage\: /silkspawners locale [setting/reload/update]
+COMMAND_SILKSPAWNERS_HELP_MESSAGE_CONFIG = $7Use this command to reload the configuration from the config.yml file. \nUsage\: /silkspawners config reload
 
 COMMAND_SILKSPAWNERS_GIVE_USAGE = $ePlease use /silkspawners give <Player> <Mob> [Amount]
 COMMAND_SILKSPAWNERS_GIVE_PLAYER_NOT_FOUND = $7The player $c{0}$7 is not online.
@@ -142,6 +143,7 @@ COMMAND_SILKSPAWNERS_SET_ENTITY_NOT_FOUND = $7The entity $c{0}$7 is no valid spa
 COMMAND_SILKSPAWNERS_SET_INSUFFICIENT_ENTITY_PERMISSION = $7You do not have the permission to set spawners to $c{0}$7.
 COMMAND_SILKSPAWNERS_SET_INVALID_TARGET = $7You must look at a spawner to change.
 COMMAND_SILKSPAWNERS_SET_SUCCESS = $7Successfully set spawner to {0}$7.
+COMMAND_SILKSPAWNERS_SET_UNCHANGED = $7The spawner is already set to {0}$7.
 
 COMMAND_SILKSPAWNERS_EXPLOSION_USAGE = $ePlease use /silkspawners explosion <enable/disable/setting> <Player>
 COMMAND_SILKSPAWNERS_EXPLOSION_PLAYER_NOT_FOUND = $7The Player $c{0}$7 is not online.
@@ -162,6 +164,7 @@ COMMAND_SILKSPAWNERS_LOCALE_USAGE = $ePlease use /silkspawners locale [setting/r
 COMMAND_SILKSPAWNERS_LOCALE_SETTING = $7The currently used locale is {0}. Available locales are\: {1}
 COMMAND_SILKSPAWNERS_LOCALE_RELOAD_SUCCESSFUL = $7The locale was reloaded successfully.
 COMMAND_SILKSPAWNERS_LOCALE_RELOAD_ERROR = $cAn error occurred reloading the locale.
+COMMAND_SILKSPAWNERS_LOCALE_INCOMPLETE = $eThe locale {0} is incomplete ({1}% translated).$7 Untranslated messages are shown in English.\nYou can help completing the translation at {2}
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_WARNING = $eWarning\!$7 Updating the locale files will $coverwrite all changes$7.\n If you want to proceed, run /silkspawners locale update confirm.
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_SUCCESSFUL = $7The locale files were updated and reloaded successfully.
 COMMAND_SILKSPAWNERS_LOCALE_UPDATE_ERROR = $cAn error occurred.$7 Please contact the developer if this problem persists.
@@ -178,12 +181,15 @@ COMMAND_SILKSPAWNERS_CONFIG_RELOAD_ERROR = $7An $cerror$7 occurred reloading the
 
 [B][FONT=Verdana][SIZE=6][COLOR=#0059b3]Integrations[/COLOR][/SIZE][/FONT][/B]
 
+[B][SIZE=5]EconomyShopGUI[/SIZE][/B]
+[SIZE=4][URL='https://www.spigotmc.org/resources/economyshopgui.69927/']EconomyShopGUI[/URL] supports SilkSpawners out of the box, so spawners bought and sold in its shops are SilkSpawners items. Its [B]spawner-provider[/B] option detects SilkSpawners automatically when set to [B]AUTO[/B] (the default), or can be pinned with [B]spawner-provider: SILKSPAWNERSV2[/B].[/SIZE]
+
 [B][SIZE=5]ShopGUI+[/SIZE][/B]
 [SIZE=4]If [URL='https://www.spigotmc.org/resources/shopgui-1-8-1-21.6515/']ShopGUI+[/URL] is installed, SilkSpawners automatically registers itself as its spawner provider, so spawners bought and sold in shops are SilkSpawners items. The hook can be disabled by setting [B]hooks.shopguiplus[/B] to [B]false[/B] in the configuration.[/SIZE]
 
 [B][FONT=Verdana][SIZE=6][COLOR=#0059b3]For developers[/COLOR][/SIZE][/FONT][/B]
 
-[SIZE=4]SilkSpawners fires custom Bukkit events ([B]SpawnerPlaceEvent[/B], [B]SpawnerBreakEvent[/B]) that other plugins can listen to. See the [URL='https://github.com/CorneliusMa/SilkSpawners_v2/blob/master/docs/DEVELOPERS.md']Developer documentation[/URL] for details.[/SIZE]
+[SIZE=4]SilkSpawners provides a developer API with a [B]SilkSpawnersAPI[/B] service and custom Bukkit events. See the [URL='https://github.com/CorneliusMa/SilkSpawners_v2/blob/master/docs/DEVELOPERS.md']Developer documentation[/URL] for details.[/SIZE]
 
 [B][FONT=Verdana][SIZE=6][COLOR=#0059b3]Tutorial[/COLOR][/SIZE][/FONT][/B]
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ If [ShopGUI+](https://www.spigotmc.org/resources/shopgui-1-8-1-21.6515/) is inst
 
 ## For developers
 
-SilkSpawners provides a developer API (via JitPack) with a `SilkSpawnersAPI` service and custom Bukkit events. See the [Developer documentation](docs/DEVELOPERS.md) and the [Javadoc](https://javadoc.jitpack.io/com/github/CorneliusMa/SilkSpawners_v2/api-0.1.1/javadoc/) for details.
+SilkSpawners provides a developer API with a `SilkSpawnersAPI` service and custom Bukkit events. See the [Developer documentation](docs/DEVELOPERS.md) for details.
 
 ## Tutorial
 

--- a/docs/DEVELOPERS.md
+++ b/docs/DEVELOPERS.md
@@ -2,7 +2,7 @@
 
 For plugin developers who want to integrate with SilkSpawners.
 
-SilkSpawners exposes a single artifact, published via [JitPack](https://jitpack.io). It contains the `SilkSpawnersAPI` service, spawner snapshots and all custom events. Use the API release tag (e.g. `api-0.1.1`) as the version. The [Javadoc](https://javadoc.jitpack.io/com/github/CorneliusMa/SilkSpawners_v2/api-0.1.1/javadoc/) is hosted on JitPack as well.
+SilkSpawners exposes a single artifact, published via [JitPack](https://jitpack.io). It contains the `SilkSpawnersAPI` service, spawner snapshots and all custom events. Use the API release tag (e.g. `api-1.0.0`) as the version. The [Javadoc](https://javadoc.jitpack.io/com/github/CorneliusMa/SilkSpawners_v2/api-1.0.0/javadoc/) is hosted on JitPack as well.
 
 Gradle:
 
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly("com.github.CorneliusMa:SilkSpawners_v2:api-0.1.1")
+    compileOnly("com.github.CorneliusMa:SilkSpawners_v2:api-1.0.0")
 }
 ```
 
@@ -30,7 +30,7 @@ Maven:
     <dependency>
         <groupId>com.github.CorneliusMa</groupId>
         <artifactId>SilkSpawners_v2</artifactId>
-        <version>api-0.1.1</version>
+        <version>api-1.0.0</version>
         <scope>provided</scope>
     </dependency>
 </dependencies>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-pluginVersion=2.4.0
-apiVersion=0.1.1
+pluginVersion=3.0.0
+apiVersion=1.0.0
 
 org.gradle.parallel=true
 org.gradle.caching=true


### PR DESCRIPTION
### Added
- Developer API (#89)
- Spawner items are named after their mob: new `{entity}` placeholder in `spawner.item.name` (#112, resolves #58)
- Mined spawners keep their block settings
- New `spawner.item.color` option for the color of the mob name in chat messages (#112)
- Spawner lore is now freely editable via spawner.item.lore and shows `Spawns <mob>` by default, using the same `{entity}` placeholder
- `spawner.item.prefixOld` accepts a list of previous lore prefixes so spawner items from older versions stay recognized (#112)
- Incomplete locales fall back to English for untranslated messages (#113)
- `/silkspawners set` reports when the spawner already spawns the given mob (#89)
- Updated community translations

### Fixed
- Spawner items no longer show the vanilla "Interact with Spawn Egg" tooltip (#126, resolves #67)
- Changing `messages.locale` now takes effect on `/silkspawners config reload` (#113)
- Messages containing apostrophes are displayed correctly (#121)
- The update check no longer reports an update when the installed version is newer than the latest release (#111)
- `/silkspawners help config` shows the command's help message instead of missing (#89)