### PR TITLE
fix crashes in locale loading, version parsing, and entity resolution

### DIFF
--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/EntitiesCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/EntitiesCommand.java
@@ -2,8 +2,8 @@ package de.corneliusmay.silkspawners.plugin.commands;
 
 import de.corneliusmay.silkspawners.plugin.commands.handler.SilkSpawnersCommand;
 import de.corneliusmay.silkspawners.plugin.spawner.SpawnableEntities;
+import de.corneliusmay.silkspawners.plugin.spawner.Spawner;
 import de.corneliusmay.silkspawners.wiring.Wired;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.EntityType;
@@ -23,8 +23,7 @@ public class EntitiesCommand extends SilkSpawnersCommand {
                 sender,
                 "MESSAGE",
                 SpawnableEntities.TYPES.stream()
-                        .map(EntityType::getName)
-                        .filter(Objects::nonNull)
+                        .map(Spawner::serializedEntityType)
                         .collect(Collectors.joining(", ")));
 
         return true;

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/GiveCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/GiveCommand.java
@@ -4,6 +4,7 @@ import de.corneliusmay.silkspawners.api.events.SpawnerGiveEvent;
 import de.corneliusmay.silkspawners.plugin.commands.completers.EntityTabCompleter;
 import de.corneliusmay.silkspawners.plugin.commands.completers.OnlinePlayersTabCompleter;
 import de.corneliusmay.silkspawners.plugin.commands.handler.SilkSpawnersCommand;
+import de.corneliusmay.silkspawners.plugin.spawner.EntityNames;
 import de.corneliusmay.silkspawners.plugin.spawner.Spawner;
 import de.corneliusmay.silkspawners.plugin.spawner.SpawnerFactory;
 import de.corneliusmay.silkspawners.spi.platform.ServerPlatform;
@@ -42,7 +43,7 @@ public class GiveCommand extends SilkSpawnersCommand {
         if (args[1].equalsIgnoreCase(Spawner.EMPTY)) {
             entityType = null;
         } else {
-            entityType = EntityType.fromName(args[1]);
+            entityType = EntityNames.resolve(args[1]);
             if (entityType == null) {
                 sendMessage(sender, "ENTITY_NOT_FOUND", args[1]);
                 return false;

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/SetCommand.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/SetCommand.java
@@ -3,6 +3,7 @@ package de.corneliusmay.silkspawners.plugin.commands;
 import de.corneliusmay.silkspawners.api.events.SpawnerChangeEvent;
 import de.corneliusmay.silkspawners.plugin.commands.completers.EntityTabCompleter;
 import de.corneliusmay.silkspawners.plugin.commands.handler.SilkSpawnersCommand;
+import de.corneliusmay.silkspawners.plugin.spawner.EntityNames;
 import de.corneliusmay.silkspawners.plugin.spawner.Spawner;
 import de.corneliusmay.silkspawners.plugin.spawner.SpawnerFactory;
 import de.corneliusmay.silkspawners.spi.version.VersionAdapter;
@@ -39,7 +40,7 @@ public class SetCommand extends SilkSpawnersCommand {
         if (args[0].equalsIgnoreCase(Spawner.EMPTY)) {
             entityType = null;
         } else {
-            entityType = EntityType.fromName(args[0]);
+            entityType = EntityNames.resolve(args[0]);
             if (entityType == null) {
                 sendMessage(sender, "ENTITY_NOT_FOUND", args[0]);
                 return false;

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/completers/EntityTabCompleter.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/commands/completers/EntityTabCompleter.java
@@ -18,8 +18,7 @@ public class EntityTabCompleter implements TabCompletion {
         entityTypes.add(null); // empty
         entityTypes.addAll(SpawnableEntities.TYPES);
         return entityTypes.stream()
-                .map(entityType -> entityType == null ? Spawner.EMPTY : entityType.getName())
-                .filter(Objects::nonNull)
+                .map(Spawner::serializedEntityType)
                 .filter((entity) -> {
                     if (sender.hasPermission(command.getPermissionString() + "." + entity)) return true;
                     else return sender.hasPermission(command.getPermissionString() + ".*");

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/locale/LocaleFiles.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/locale/LocaleFiles.java
@@ -11,9 +11,11 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystem;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
+import java.nio.file.ProviderNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
@@ -48,37 +50,67 @@ class LocaleFiles {
     synchronized void copy(boolean overwrite) throws URISyntaxException, IOException {
         Path target = path().toPath();
         Map<String, Map<String, Set<String>>> signatures = LocaleMerger.signatures(signatureLines());
-        URI resource = getClass().getResource("").toURI();
+        URI resource = getClass().getResource("/locales").toURI();
         List<String> failed = new ArrayList<>();
-        try (FileSystem fileSystem = FileSystems.newFileSystem(resource, Collections.<String, String>emptyMap())) {
-            final Path jarPath = fileSystem.getPath("/locales");
-
-            Files.walkFileTree(jarPath, new SimpleFileVisitor<>() {
-                @Override
-                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-                    Files.createDirectories(
-                            target.resolve(jarPath.relativize(dir).toString()));
-                    return FileVisitResult.CONTINUE;
+        if ("file".equalsIgnoreCase(resource.getScheme())) {
+            Path jarPath = Path.of(resource);
+            walkAndSync(jarPath, jarPath, target, signatures, overwrite, failed);
+        } else {
+            FileSystem fileSystem = null;
+            boolean created = false;
+            try {
+                try {
+                    fileSystem = FileSystems.getFileSystem(resource);
+                } catch (FileSystemNotFoundException ex) {
+                    fileSystem = FileSystems.newFileSystem(resource, Collections.emptyMap());
+                    created = true;
+                } catch (ProviderNotFoundException ex) {
+                    fileSystem = FileSystems.newFileSystem(resource, Collections.emptyMap());
+                    created = true;
                 }
-
-                @Override
-                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                    String relative = jarPath.relativize(file).toString();
-                    try {
-                        List<String> bundled = read(file);
-                        if (isEmpty(bundled)) return FileVisitResult.CONTINUE;
-                        Map<String, Set<String>> locale = signatures.getOrDefault(localeCode(relative), Map.of());
-                        sync(bundled, target.resolve(relative), locale, overwrite);
-                    } catch (IOException | IllegalArgumentException ex) {
-                        Logger.warn("Could not " + (overwrite ? "restore " : "update ") + relative + ": "
-                                + ex.getMessage());
-                        failed.add(relative);
-                    }
-                    return FileVisitResult.CONTINUE;
+                Path jarPath = fileSystem.getPath("/locales");
+                walkAndSync(jarPath, jarPath, target, signatures, overwrite, failed);
+            } finally {
+                if (created && fileSystem != null) {
+                    fileSystem.close();
                 }
-            });
+            }
         }
         if (!failed.isEmpty() && overwrite) throw new IOException("Could not restore " + String.join(", ", failed));
+    }
+
+    private void walkAndSync(
+            Path jarPath,
+            Path startPath,
+            Path target,
+            Map<String, Map<String, Set<String>>> signatures,
+            boolean overwrite,
+            List<String> failed)
+            throws IOException {
+        Files.walkFileTree(startPath, new SimpleFileVisitor<>() {
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+                Files.createDirectories(
+                        target.resolve(jarPath.relativize(dir).toString()));
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                String relative = jarPath.relativize(file).toString();
+                try {
+                    List<String> bundled = read(file);
+                    if (isEmpty(bundled)) return FileVisitResult.CONTINUE;
+                    Map<String, Set<String>> locale = signatures.getOrDefault(localeCode(relative), Map.of());
+                    sync(bundled, target.resolve(relative), locale, overwrite);
+                } catch (IOException | IllegalArgumentException ex) {
+                    Logger.warn("Could not " + (overwrite ? "restore " : "update ") + relative + ": "
+                            + ex.getMessage());
+                    failed.add(relative);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 
     private void sync(List<String> bundled, Path current, Map<String, Set<String>> signatures, boolean overwrite)

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/spawner/EntityNames.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/spawner/EntityNames.java
@@ -4,7 +4,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.bukkit.entity.EntityType;
 
-final class EntityNames {
+public final class EntityNames {
 
     // Each legacy name maps to its immediate successor, so resolution stops at the first name the server knows
     private static final Map<String, String> RENAMES = Map.ofEntries(
@@ -27,7 +27,7 @@ final class EntityNames {
 
     private EntityNames() {}
 
-    static EntityType resolve(String serializedName) {
+    public static EntityType resolve(String serializedName) {
         for (String name = serializedName; name != null; name = RENAMES.get(name)) {
             EntityType entityType = EntityType.fromName(name);
             if (entityType != null) return entityType;

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/spawner/Spawner.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/spawner/Spawner.java
@@ -52,7 +52,7 @@ public class Spawner implements SpawnerSnapshot {
         return itemStack != null && (isEmpty() || entityType.isSpawnable());
     }
 
-    static String serializedEntityType(EntityType entityType) {
+    public static String serializedEntityType(EntityType entityType) {
         if (entityType == null) return EMPTY;
         String name = entityType.getName();
         return (name == null ? entityType.name() : name).toLowerCase();

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/utils/MessageRenderer.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/utils/MessageRenderer.java
@@ -34,6 +34,7 @@ public class MessageRenderer {
     }
 
     public static String render(String template, Object... args) {
+        if (template == null) return null;
         if (isMixed(template)) throw new MixedFormattingException();
         // Crowdin only escapes apostrophes in strings containing variables, so plain strings must skip MessageFormat
         if (template.indexOf('§') != -1) return args.length == 0 ? template : MessageFormat.format(template, args);

--- a/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/VersionChecker.java
+++ b/Plugin/src/main/java/de/corneliusmay/silkspawners/plugin/version/VersionChecker.java
@@ -120,7 +120,9 @@ public class VersionChecker implements Loader {
     }
 
     private int[] parseVersion(String version) {
-        return Arrays.stream(version.split("\\.")).mapToInt(Integer::parseInt).toArray();
+        return Arrays.stream(version.split("-")[0].split("\\."))
+                .mapToInt(Integer::parseInt)
+                .toArray();
     }
 
     private String updateAvailableMessage(String latestVersion) {


### PR DESCRIPTION
- fixed `FileSystemAlreadyExistsException` and `IllegalArgumentException` when loading or reloading locale files
- updated give and set commands to use `EntityNames.resolve` so legacy entity names and newer mobs are handled properly
- updated tab completion and entities command to use `Spawner::serializedEntityType` instead of `EntityType::getName` which returned `null` for newer entities
- added pre-release suffix stripping in `VersionChecker` to prevent `NumberFormatException`
- added a null check in `MessageRenderer.render` to avoid NPEs when passing null templates